### PR TITLE
OTP Refactor

### DIFF
--- a/cmd/fullstack-otp/main.go
+++ b/cmd/fullstack-otp/main.go
@@ -13,28 +13,35 @@ func main() {
 	// OTP metrics.
 	// Reference: https://datatracker.ietf.org/doc/html/rfc6238.
 	sharedSecret := base32.StdEncoding.EncodeToString([]byte("The quick brown fox jumps over the lazy dog."))
-	period := 30
-	digits := 10
-	currentTime := time.Now().Unix()
-	counter := currentTime / int64(period)
-	hashFunction := sha512.New
+	totpConfig := otp.TOTPConfig{
+		Secret:    sharedSecret,
+		Period:    30,
+		Digits:    10,
+		Timestamp: time.Now().Unix(),
+		Hasher:    sha512.New,
+	}
 
 	// Create OTP.
-	token, err := otp.Generate(counter, digits, sharedSecret, hashFunction)
+	token, err := otp.Generate(totpConfig)
 	if err != nil {
 		panic(err)
 	}
 
 	// Get my OTP.
 	success := fmt.Sprintf(
-		"My OTP is '%s', with shared secret '%s', with the counter being '%d' and current time being '%d'.", *token, sharedSecret, counter, currentTime,
+		"My OTP is '%s', with shared secret '%s', with current time being '%d'.", token, sharedSecret, totpConfig.Timestamp,
 	)
 	fmt.Println(success)
 
 	// Verify my OTP.
-	currentTimeMore := time.Now().Add(30*time.Second).Unix() / int64(period)
-
-	res, err := otp.Verify(token, currentTimeMore, digits, sharedSecret, hashFunction)
+	res, err := otp.Verify(token, otp.TOTPValidateConfig{
+		Secret:    sharedSecret,
+		Period:    30,
+		Digits:    10,
+		Timestamp: time.Now().Unix(),
+		Hasher:    sha512.New,
+		Window:    1,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/otp/otp.go
+++ b/internal/otp/otp.go
@@ -71,7 +71,7 @@ func Verify(otp string, options TOTPValidateConfig) (bool, error) {
 	}
 
 	// We will try to safely compare two strings at a single moment.
-	// Also try to generate tokens in allowed windows. If one match, then allow token is valid.
+	// Also try to generate tokens in allowed windows. If one match, then that token is valid.
 	for i := counter - options.Window; i <= counter+options.Window; i++ {
 		generatedToken, err := Generate(TOTPConfig{
 			Secret:    options.Secret,
@@ -92,8 +92,7 @@ func Verify(otp string, options TOTPValidateConfig) (bool, error) {
 	return false, nil
 }
 
-// This function will return generate a new OTP.
-// Will take a counter in the form of UNIX time.
+// This function will generate a new OTP. In this case, it's TOTP.
 // Reference: https://datatracker.ietf.org/doc/html/rfc6238.
 func Generate(options TOTPConfig) (string, error) {
 	// Calculate counters.

--- a/internal/otp/otp.go
+++ b/internal/otp/otp.go
@@ -12,6 +12,25 @@ import (
 	"strings"
 )
 
+// TOTPConfig in order to act as a baseline of TOTP configurations.
+type TOTPConfig struct {
+	Secret    string           // OTP shared secret.
+	Period    int64            // Period of the token will be validated.
+	Timestamp int64            // Timestamp or current time in UNIX time.
+	Digits    int              // Digits requested for the OTP.
+	Hasher    func() hash.Hash // Hash algorithm for the OTP.
+}
+
+// TOTPValidateConfig to configure validation parameters.
+type TOTPValidateConfig struct {
+	Secret    string           // OTP shared secret.
+	Period    int64            // Period of the token will be validated.
+	Timestamp int64            // Timestamp or current time in UNIX time.
+	Digits    int              // Digits requested for the OTP.
+	Hasher    func() hash.Hash // Hash algorithm for the OTP.
+	Window    int64            // How long in a timeframe should an OTP be tolerated.
+}
+
 // This function is an utility function to convert a secret (base32 encoded) into byte form.
 func transformSecret(sharedSecret string) ([]byte, error) {
 	// Transform into bytes.
@@ -41,24 +60,31 @@ func pad(otp, digits int) string {
 
 // This function will validate a TOTP using constant time compare.
 // Window is used as the interval - the window of counter values to test.
-func Verify(otp *string, counter int64, digits int, secret string, hasher func() hash.Hash) (bool, error) {
-	var window int64 = 1
-	passcode := strings.TrimSpace(*otp)
+func Verify(otp string, options TOTPValidateConfig) (bool, error) {
+	// Remove whitespaces from the passed OTP and calculate counter.
+	passcode := strings.TrimSpace(otp)
+	counter := options.Timestamp / options.Period
 
 	// Check if the length of the OTP is not equal to specified digits.
-	if len(passcode) != digits {
+	if len(passcode) != options.Digits {
 		return false, errors.New("passcode is not equal to the specified digits in length")
 	}
 
 	// We will try to safely compare two strings at a single moment.
 	// Also try to generate tokens in allowed windows. If one match, then allow token is valid.
-	for i := counter - window; i <= counter+window; i++ {
-		generatedToken, err := Generate(i, digits, secret, hasher)
+	for i := counter - options.Window; i <= counter+options.Window; i++ {
+		generatedToken, err := Generate(TOTPConfig{
+			Secret:    options.Secret,
+			Period:    options.Period,
+			Timestamp: options.Timestamp,
+			Digits:    options.Digits,
+			Hasher:    options.Hasher,
+		})
 		if err != nil {
 			return false, err
 		}
 
-		if subtle.ConstantTimeCompare([]byte(passcode), []byte(*generatedToken)) == 1 {
+		if subtle.ConstantTimeCompare([]byte(passcode), []byte(generatedToken)) == 1 {
 			return true, nil
 		}
 	}
@@ -69,15 +95,13 @@ func Verify(otp *string, counter int64, digits int, secret string, hasher func()
 // This function will return generate a new OTP.
 // Will take a counter in the form of UNIX time.
 // Reference: https://datatracker.ietf.org/doc/html/rfc6238.
-func Generate(counter int64, digits int, secret string, hasher func() hash.Hash) (*string, error) {
-	// Check if counter is a negative number.
-	if counter < 0 {
-		return nil, errors.New("input must be positive integer")
-	}
+func Generate(options TOTPConfig) (string, error) {
+	// Calculate counters.
+	counter := options.Timestamp / options.Period
 
 	// Removes whitespaces for some secrets.
 	// Transform to uppercase to conform to the RFC.
-	secretTrimmed := strings.TrimSpace(secret)
+	secretTrimmed := strings.TrimSpace(options.Secret)
 	secretTrimmed = strings.ToUpper(secretTrimmed)
 
 	// Transform 'counter' into a byte array.
@@ -86,11 +110,11 @@ func Generate(counter int64, digits int, secret string, hasher func() hash.Hash)
 	// Transform 'secret' into a byte array.
 	secretInBytes, err := transformSecret(secretTrimmed)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Create a new OTP token based on the inputs.
-	hmac := hmac.New(hasher, secretInBytes)
+	hmac := hmac.New(options.Hasher, secretInBytes)
 	hmac.Write(counterInBytes)
 	digest := hmac.Sum(nil)
 
@@ -101,11 +125,11 @@ func Generate(counter int64, digits int, secret string, hasher func() hash.Hash)
 		((int(digest[offset+1] & 255)) << 16) |
 		((int(digest[offset+2] & 255)) << 8) |
 		(int(digest[offset+3] & 255))
-	otp = otp % int(math.Pow10(digits))
+	otp = otp % int(math.Pow10(options.Digits))
 
 	// Pad the OTP with leading zeroes.
-	token := pad(otp, digits)
+	token := pad(otp, options.Digits)
 
 	// Return the newly created OTP.
-	return &token, nil
+	return token, nil
 }

--- a/internal/otp/otp_test.go
+++ b/internal/otp/otp_test.go
@@ -232,6 +232,18 @@ func TestVerify(t *testing.T) {
 				Window:    1,
 			},
 		},
+		{
+			name: "test_invalid_random_otp",
+			otp:  "1234567890",
+			totpValidation: TOTPValidateConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: 1629787555,
+				Digits:    10,
+				Hasher:    sha512.New,
+				Window:    1,
+			},
+		},
 	}
 
 	successTests := []struct {

--- a/internal/otp/otp_test.go
+++ b/internal/otp/otp_test.go
@@ -178,13 +178,13 @@ func TestVerify(t *testing.T) {
 			},
 		},
 		{
-			name: "test_otp_fail_counter",
+			name: "test_otp_invalid_secret_base32",
 			otp:  "000000",
 			totpValidation: TOTPValidateConfig{
-				Secret:    sharedSecret,
+				Secret:    "invalid_base32",
 				Period:    int64(period),
-				Timestamp: -1,
-				Digits:    10,
+				Timestamp: 1629780615,
+				Digits:    6,
 				Hasher:    sha512.New,
 				Window:    1,
 			},

--- a/internal/otp/otp_test.go
+++ b/internal/otp/otp_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/base32"
-	"hash"
 	"testing"
 )
 
@@ -65,75 +64,78 @@ func TestPad(t *testing.T) {
 
 func TestGenerate(t *testing.T) {
 	sharedSecret := toBase32("The quick brown fox jumps over the lazy dog.")
+	period := 30
 
 	failureTests := []struct {
-		name    string
-		counter int64
-		digits  int
-		secret  string
-		hasher  func() hash.Hash
+		name       string
+		totpConfig TOTPConfig
 	}{
 		{
-			name:    "test_negative_input",
-			counter: -1,
-			digits:  6,
-			secret:  sharedSecret,
-			hasher:  sha512.New,
-		},
-		{
-			name:    "test_invalid_base32",
-			counter: 123,
-			digits:  6,
-			secret:  "invalid_base32",
-			hasher:  sha512.New,
+			name: "test_invalid_base32",
+			totpConfig: TOTPConfig{
+				Secret:    "invalid_base32",
+				Period:    int64(period),
+				Timestamp: 1629794446,
+				Digits:    10,
+				Hasher:    sha512.New,
+			},
 		},
 	}
 
 	successTests := []struct {
 		name           string
-		counter        int64
-		digits         int
-		secret         string
-		hasher         func() hash.Hash
+		totpConfig     TOTPConfig
 		expectedOutput string
 	}{
 		{
-			name:           "test_otp_1_10_digits",
-			counter:        54324343,
-			digits:         10,
-			secret:         sharedSecret,
-			hasher:         sha512.New,
-			expectedOutput: "0582933009",
+			name: "test_otp_1_10_digits",
+			totpConfig: TOTPConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: 1629794237,
+				Digits:    10,
+				Hasher:    sha512.New,
+			},
+			expectedOutput: "2091961511",
 		},
 		{
-			name:           "test_otp_2_6_digits",
-			counter:        54324351,
-			digits:         6,
-			secret:         sharedSecret,
-			hasher:         sha512.New,
-			expectedOutput: "934368",
+			name: "test_otp_2_6_digits",
+			totpConfig: TOTPConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: 1629794237,
+				Digits:    6,
+				Hasher:    sha512.New,
+			},
+			expectedOutput: "961511",
 		},
 		{
-			name:           "test_otp_3_sha256_hasher",
-			counter:        54324354,
-			digits:         6,
-			secret:         sharedSecret,
-			hasher:         sha256.New,
-			expectedOutput: "181011",
+			name: "test_otp_3_sha256_hasher",
+			totpConfig: TOTPConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: 1629794392,
+				Digits:    10,
+				Hasher:    sha256.New,
+			},
+			expectedOutput: "0097957743",
 		},
 		{
-			name:           "test_otp_4_60_period",
-			counter:        27162206,
-			digits:         10,
-			secret:         sharedSecret,
-			hasher:         sha512.New,
-			expectedOutput: "1796746380",
+			name: "test_otp_4_60_period_sha256",
+			totpConfig: TOTPConfig{
+				Secret:    sharedSecret,
+				Period:    60,
+				Timestamp: 1629794446,
+				Digits:    10,
+				Hasher:    sha256.New,
+			},
+			expectedOutput: "0565820944",
 		},
 	}
 
 	for _, tt := range failureTests {
 		t.Run(tt.name, func(t *testing.T) {
-			otp, err := Generate(tt.counter, tt.digits, tt.secret, tt.hasher)
+			otp, err := Generate(tt.totpConfig)
 			if err == nil {
 				t.Errorf("Test-cases should return error(s)! Got: %v!", otp)
 			}
@@ -142,13 +144,13 @@ func TestGenerate(t *testing.T) {
 
 	for _, tt := range successTests {
 		t.Run(tt.name, func(t *testing.T) {
-			otp, err := Generate(tt.counter, tt.digits, tt.secret, tt.hasher)
+			otp, err := Generate(tt.totpConfig)
 			if err != nil {
 				t.Errorf("Test-cases should not return error(s)! Got: %v, expected: %v!", err, tt.expectedOutput)
 			}
 
-			if *otp != tt.expectedOutput {
-				t.Errorf("OTP and the expected output are not the same! Got: %v, expected: %v!", *otp, tt.expectedOutput)
+			if otp != tt.expectedOutput {
+				t.Errorf("OTP and the expected output are not the same! Got: %v, expected: %v!", otp, tt.expectedOutput)
 			}
 		})
 	}
@@ -159,126 +161,161 @@ func TestVerify(t *testing.T) {
 	period := 30
 
 	errorTests := []struct {
-		name    string
-		otp     string
-		counter int64
-		digits  int
-		secret  string
-		hasher  func() hash.Hash
+		name           string
+		otp            string
+		totpValidation TOTPValidateConfig
 	}{
 		{
-			name:    "test_otp_not_enough_length",
-			otp:     "1234",
-			counter: 1629780615 / int64(period),
-			digits:  10,
-			secret:  sharedSecret,
-			hasher:  sha512.New,
+			name: "test_otp_not_enough_length",
+			otp:  "1234",
+			totpValidation: TOTPValidateConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: 1629780615,
+				Digits:    10,
+				Hasher:    sha512.New,
+				Window:    1,
+			},
 		},
 		{
-			name:    "test_otp_fail_counter",
-			otp:     "000000",
-			counter: -1,
-			digits:  6,
-			secret:  sharedSecret,
-			hasher:  sha512.New,
+			name: "test_otp_fail_counter",
+			otp:  "000000",
+			totpValidation: TOTPValidateConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: -1,
+				Digits:    10,
+				Hasher:    sha512.New,
+				Window:    1,
+			},
 		},
 	}
 
 	invalidTests := []struct {
-		name            string
-		otp             string
-		verifyTimestamp int64
-		digits          int
-		secret          string
-		hasher          func() hash.Hash
+		name           string
+		otp            string
+		totpValidation TOTPValidateConfig
 	}{
 		{
-			name:            "test_otp_invalid_because_more_than_30_seconds",
-			otp:             "1736605286", // OTP generated at 1629787611.
-			verifyTimestamp: 1629787651,   // sometimes, it can be valid for a bit more than 30 seconds.
-			digits:          10,
-			secret:          sharedSecret,
-			hasher:          sha512.New,
+			name: "test_otp_invalid_because_more_than_30_seconds",
+			otp:  "1736605286", // OTP generated at 1629787611.
+			totpValidation: TOTPValidateConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: 1629787651, // sometimes, it can be valid for a bit more than 30 seconds.
+				Digits:    10,
+				Hasher:    sha512.New,
+				Window:    1,
+			},
 		},
 		{
-			name:            "test_otp_all_zeroes",
-			otp:             "000000",
-			verifyTimestamp: 1629787651, // taken from the above.
-			digits:          6,
-			secret:          sharedSecret,
-			hasher:          sha512.New,
+			name: "test_otp_all_zeroes",
+			otp:  "000000",
+			totpValidation: TOTPValidateConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: 1629787651, // taken from the above.
+				Digits:    6,
+				Hasher:    sha512.New,
+				Window:    1,
+			},
 		},
 		{
-			name:            "test_otp_before_timestamp",
-			otp:             "1736605286", // OTP generated at 1629787611.
-			verifyTimestamp: 1629787555,   // 56 seconds before OTP generation time
-			digits:          10,
-			secret:          sharedSecret,
-			hasher:          sha512.New,
+			name: "test_otp_before_timestamp",
+			otp:  "1736605286", // OTP generated at 1629787611.
+			totpValidation: TOTPValidateConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: 1629787555, // 56 seconds before OTP generation time.
+				Digits:    10,
+				Hasher:    sha512.New,
+				Window:    1,
+			},
 		},
 	}
 
 	successTests := []struct {
-		name            string
-		otp             string
-		verifyTimestamp int64
-		digits          int
-		secret          string
-		hasher          func() hash.Hash
+		name           string
+		otp            string
+		totpValidation TOTPValidateConfig
 	}{
 		{
-			name:            "test_otp_5_seconds",
-			otp:             "1941056642", // OTP generated at 1629787672
-			verifyTimestamp: 1629787677,
-			digits:          10,
-			secret:          sharedSecret,
-			hasher:          sha512.New,
+			name: "test_otp_5_seconds",
+			otp:  "2053730166", // OTP generated at 1629795960
+			totpValidation: TOTPValidateConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: 1629795965,
+				Digits:    10,
+				Hasher:    sha512.New,
+				Window:    1,
+			},
 		},
 		{
-			name:            "test_otp_10_seconds",
-			otp:             "1941056642", // OTP generated at 1629787672
-			verifyTimestamp: 1629787682,
-			digits:          10,
-			secret:          sharedSecret,
-			hasher:          sha512.New,
+			name: "test_otp_10_seconds",
+			otp:  "2053730166", // OTP generated at 1629795960
+			totpValidation: TOTPValidateConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: 1629795970,
+				Digits:    10,
+				Hasher:    sha512.New,
+				Window:    1,
+			},
 		},
 		{
-			name:            "test_otp_15_seconds",
-			otp:             "1941056642", // OTP generated at 1629787672
-			verifyTimestamp: 1629787687,
-			digits:          10,
-			secret:          sharedSecret,
-			hasher:          sha512.New,
+			name: "test_otp_15_seconds",
+			otp:  "2053730166", // OTP generated at 1629795960
+			totpValidation: TOTPValidateConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: 1629795975,
+				Digits:    10,
+				Hasher:    sha512.New,
+				Window:    1,
+			},
 		},
 		{
-			name:            "test_otp_20_seconds",
-			otp:             "1941056642", // OTP generated at 1629787672
-			verifyTimestamp: 1629787692,
-			digits:          10,
-			secret:          sharedSecret,
-			hasher:          sha512.New,
+			name: "test_otp_20_seconds",
+			otp:  "2053730166", // OTP generated at 1629795960
+			totpValidation: TOTPValidateConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: 1629795980,
+				Digits:    10,
+				Hasher:    sha512.New,
+				Window:    1,
+			},
 		},
 		{
-			name:            "test_otp_25_seconds",
-			otp:             "1941056642", // OTP generated at 1629787672
-			verifyTimestamp: 1629787697,
-			digits:          10,
-			secret:          sharedSecret,
-			hasher:          sha512.New,
+			name: "test_otp_25_seconds",
+			otp:  "2053730166", // OTP generated at 1629795960
+			totpValidation: TOTPValidateConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: 1629795985,
+				Digits:    10,
+				Hasher:    sha512.New,
+				Window:    1,
+			},
 		},
 		{
-			name:            "test_otp_30_seconds",
-			otp:             "1941056642", // OTP generated at 1629787672
-			verifyTimestamp: 1629787702,
-			digits:          10,
-			secret:          sharedSecret,
-			hasher:          sha512.New,
+			name: "test_otp_30_seconds",
+			otp:  "2053730166", // OTP generated at 1629795960
+			totpValidation: TOTPValidateConfig{
+				Secret:    sharedSecret,
+				Period:    int64(period),
+				Timestamp: 1629795989, // 1 second before 30 seconds
+				Digits:    10,
+				Hasher:    sha512.New,
+				Window:    1,
+			},
 		},
 	}
 
 	for _, tt := range errorTests {
 		t.Run(tt.name, func(t *testing.T) {
-			valid, err := Verify(&tt.otp, tt.counter, tt.digits, tt.secret, tt.hasher)
+			valid, err := Verify(tt.otp, tt.totpValidation)
 			if err == nil {
 				t.Errorf("Test case should return an error! Got: %v, expected: %v!", err, valid)
 			}
@@ -287,9 +324,7 @@ func TestVerify(t *testing.T) {
 
 	for _, tt := range invalidTests {
 		t.Run(tt.name, func(t *testing.T) {
-			verifyCounter := tt.verifyTimestamp / int64(period)
-
-			valid, err := Verify(&tt.otp, verifyCounter, tt.digits, tt.secret, tt.hasher)
+			valid, err := Verify(tt.otp, tt.totpValidation)
 			if err != nil {
 				t.Errorf("Verification test-cases should not return error(s)! Got: %v!", err)
 			}
@@ -302,9 +337,7 @@ func TestVerify(t *testing.T) {
 
 	for _, tt := range successTests {
 		t.Run(tt.name, func(t *testing.T) {
-			verifyCounter := tt.verifyTimestamp / int64(period)
-
-			valid, err := Verify(&tt.otp, verifyCounter, tt.digits, tt.secret, tt.hasher)
+			valid, err := Verify(tt.otp, tt.totpValidation)
 			if err != nil {
 				t.Errorf("Verification test-cases should not return error(s)! Got: %v!", err)
 			}


### PR DESCRIPTION
This PR implements a small refactor in the `otp` package.

There is no need to pass a lot of parameters now, we just need to supply the `TOTPConfig` and `TOTPValidationConfig` to the affected functions. Tests have also been upgraded.