### PR TITLE
Baseline Webserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,7 @@ format:
 test:
 	go test -v -coverpkg ./internal/otp ./internal/otp
 	go test -v -coverpkg ./internal/application ./internal/application
+
+.PHONY: e2e
+e2e:
+	sh ./scripts/e2e-testing.sh

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ build:
 format:
 	test -z $(gofmt -l .)
 
-.PHONY:
+.PHONY: test
 test:
 	go test -v -coverpkg ./internal/otp ./internal/otp
+	go test -v -coverpkg ./internal/application ./internal/application

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Nicholas Dwiarto's Bachelor Thesis.
 
 Documentation will be written after the application is finished.
 
+## Requirements
+
+- [Docker and Docker Compose](https://www.docker.com/)
+- [Go 1.16+](https://golang.org/)
+- [Postman Agent](https://www.postman.com/downloads/)
+- Shell that supports `make`, `curl`, and `sh`. WSL / Ubuntu / OS X should be able to do this just fine without any configuration.
+
 ## Installation
 
 - Provision infrastructures.
@@ -23,3 +30,5 @@ make start
 ```bash
 make test
 ```
+
+- Run integration tests, either with `make e2e` or Postman.

--- a/cmd/fullstack-otp/main.go
+++ b/cmd/fullstack-otp/main.go
@@ -1,52 +1,70 @@
 package main
 
 import (
-	"crypto/sha512"
-	"encoding/base32"
+	"context"
 	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
-	"github.com/lauslim12/fullstack-otp/internal/otp"
+	"github.com/lauslim12/fullstack-otp/internal/application"
 )
 
+// Get port from environment variable. If it does not exist, use '8080'.
+func getPort() string {
+	port := os.Getenv("PORT")
+	if port == "" {
+		return ":8080"
+	}
+
+	return fmt.Sprintf(":%s", port)
+}
+
+// Starting point, initialize server.
 func main() {
-	// OTP metrics.
-	// Reference: https://datatracker.ietf.org/doc/html/rfc6238.
-	sharedSecret := base32.StdEncoding.EncodeToString([]byte("The quick brown fox jumps over the lazy dog."))
-	totpConfig := otp.TOTPConfig{
-		Secret:    sharedSecret,
-		Period:    30,
-		Digits:    10,
-		Timestamp: time.Now().Unix(),
-		Hasher:    sha512.New,
+	// HTTP server initialization.
+	server := &http.Server{Addr: getPort(), Handler: application.Configure()}
+
+	// Prepare context for graceful shutdown.
+	serverCtx, serverStopCtx := context.WithCancel(context.Background())
+
+	// Listen for syscall signals for process to interrupt or quit.
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	go func() {
+		<-sig
+
+		// Shutdown signal with grace period of 30 seconds.
+		shutdownCtx, shutdownCtxCancel := context.WithTimeout(serverCtx, 30*time.Second)
+		defer shutdownCtxCancel()
+		log.Println("Server starting to shutdown in 30 seconds...")
+
+		go func() {
+			<-shutdownCtx.Done()
+			if shutdownCtx.Err() == context.DeadlineExceeded {
+				log.Fatal("Graceful shutdown timeout, forcing exit.")
+			}
+		}()
+
+		// Trigger graceful shutdown here.
+		server.SetKeepAlivesEnabled(false)
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			log.Fatalf("Could not gracefully shutdown the server: %v\n", err)
+		}
+		serverStopCtx()
+	}()
+
+	// Run our server and print out starting message.
+	log.Printf("Server has started on port %s!", getPort())
+	err := server.ListenAndServe()
+	if err != nil && err != http.ErrServerClosed {
+		log.Fatal(err)
 	}
 
-	// Create OTP.
-	token, err := otp.Generate(totpConfig)
-	if err != nil {
-		panic(err)
-	}
-
-	// Get my OTP.
-	success := fmt.Sprintf(
-		"My OTP is '%s', with shared secret '%s', with current time being '%d'.", token, sharedSecret, totpConfig.Timestamp,
-	)
-	fmt.Println(success)
-
-	// Verify my OTP.
-	res, err := otp.Verify(token, otp.TOTPValidateConfig{
-		Secret:    sharedSecret,
-		Period:    30,
-		Digits:    10,
-		Timestamp: time.Now().Unix(),
-		Hasher:    sha512.New,
-		Window:    1,
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	// Get result.
-	validOTP := fmt.Sprintf("My OTP validity is %v.", res)
-	fmt.Println(validOTP)
+	// Wait for server context to be stopped.
+	<-serverCtx.Done()
+	log.Println("Server shut down successfully!")
 }

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	github.com/go-chi/chi v1.5.4
+	github.com/pquerna/otp v1.3.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/lauslim12/fullstack-otp
 
 go 1.16
+
+require (
+	github.com/go-chi/chi v1.5.4
+	github.com/stretchr/testify v1.7.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-chi/chi v1.5.4 h1:QHdzF2szwjqVV4wmByUnTcsbIg7UGaQ0tPF2t5GcAIs=
+github.com/go-chi/chi v1.5.4/go.mod h1:uaf8YgoFazUOkPBG7fxPftUylNumIev9awIWOENIuEg=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,15 @@
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi v1.5.4 h1:QHdzF2szwjqVV4wmByUnTcsbIg7UGaQ0tPF2t5GcAIs=
 github.com/go-chi/chi v1.5.4/go.mod h1:uaf8YgoFazUOkPBG7fxPftUylNumIev9awIWOENIuEg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.3.0 h1:oJV/SkzR33anKXwQU3Of42rL4wbrffP4uvUf1SvS5Xs=
+github.com/pquerna/otp v1.3.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/application/nethttp.go
+++ b/internal/application/nethttp.go
@@ -11,17 +11,19 @@ import (
 
 // SuccessResponse is used to handle successful requests.
 type SuccessResponse struct {
-	Status  string `json:"status"`
-	Code    int    `json:"code"`
-	Message string `json:"message"`
+	Status  string      `json:"status"`
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
 }
 
 // NewSuccessResponse is used to create a default, new success response.
-func NewSuccessResponse(code int, message string) *SuccessResponse {
+func NewSuccessResponse(code int, message string, data interface{}) *SuccessResponse {
 	return &SuccessResponse{
 		Status:  "success",
 		Code:    code,
 		Message: message,
+		Data:    data,
 	}
 }
 
@@ -79,7 +81,7 @@ func Configure() http.Handler {
 	r.Route("/api/v1", func(r chi.Router) {
 		// Sample GET request.
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-			res := NewSuccessResponse(http.StatusOK, "Welcome to 'net/http' API!")
+			res := NewSuccessResponse(http.StatusOK, "Welcome to 'net/http' API!", nil)
 			sendSuccessResponse(w, res)
 		})
 

--- a/internal/application/nethttp.go
+++ b/internal/application/nethttp.go
@@ -1,0 +1,103 @@
+package application
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
+)
+
+// SuccessResponse is used to handle successful requests.
+type SuccessResponse struct {
+	Status  string `json:"status"`
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// NewSuccessResponse is used to create a default, new success response.
+func NewSuccessResponse(code int, message string) *SuccessResponse {
+	return &SuccessResponse{
+		Status:  "success",
+		Code:    code,
+		Message: message,
+	}
+}
+
+// FailureResponse is used to handle failed requests.
+type FailureResponse struct {
+	Status  string `json:"status"`
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// NewFailureResponse is used to create a default, new failure response.
+func NewFailureResponse(code int, message string) *FailureResponse {
+	return &FailureResponse{
+		Status:  "fail",
+		Code:    code,
+		Message: message,
+	}
+}
+
+// Utility function to send succesful response.
+func sendSuccessResponse(w http.ResponseWriter, successResponse *SuccessResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(successResponse.Code)
+	json.NewEncoder(w).Encode(successResponse)
+}
+
+// Utility function to send failure response.
+func sendFailureResponse(w http.ResponseWriter, failureResponse *FailureResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(failureResponse.Code)
+	json.NewEncoder(w).Encode(failureResponse)
+}
+
+// Configure is used to configure the application (server is initialized in 'main').
+func Configure() http.Handler {
+	// Create a Chi instance.
+	r := chi.NewRouter()
+
+	// Set up Chi's natural middlewares.
+	r.Use(middleware.RequestID)
+	r.Use(middleware.RealIP)
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+
+	// Set up custom middleware.
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("X-Application-Name", "Fullstack OTP")
+			w.Header().Add("Server", "net/http")
+			next.ServeHTTP(w, r)
+		})
+	})
+
+	// Group routes.
+	r.Route("/api/v1", func(r chi.Router) {
+		// Sample GET request.
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			res := NewSuccessResponse(http.StatusOK, "Welcome to 'net/http' API!")
+			sendSuccessResponse(w, res)
+		})
+
+		// Declare method not allowed as a fallback.
+		r.MethodNotAllowed(func(w http.ResponseWriter, r *http.Request) {
+			errorMessage := fmt.Sprintf("Method '%s' is not allowed in this route!", r.Method)
+			res := NewFailureResponse(http.StatusMethodNotAllowed, errorMessage)
+			sendFailureResponse(w, res)
+		})
+
+		// Declare 404 every time a request reaches here.
+		r.NotFound(func(w http.ResponseWriter, r *http.Request) {
+			errorMessage := fmt.Sprintf("Route '%s' with method '%s' does not exist in this server!", r.RequestURI, r.Method)
+			res := NewFailureResponse(http.StatusNotFound, errorMessage)
+			sendFailureResponse(w, res)
+		})
+	})
+
+	// Return our configured infrastructure.
+	return r
+}

--- a/internal/application/nethttp.go
+++ b/internal/application/nethttp.go
@@ -2,8 +2,12 @@ package application
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
@@ -55,6 +59,70 @@ func sendFailureResponse(w http.ResponseWriter, failureResponse *FailureResponse
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(failureResponse.Code)
 	json.NewEncoder(w).Encode(failureResponse)
+}
+
+// Utility function to decode a JSON request body.
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst interface{}) *FailureResponse {
+	// Check if Header is 'Content-Type: application/json'.
+	if r.Header.Get("Content-Type") != "application/json" {
+		return NewFailureResponse(http.StatusUnsupportedMediaType, "The 'Content-Type' header is not 'application/json'!")
+	}
+
+	// Parse body, and set max bytes reader (512 bytes).
+	r.Body = http.MaxBytesReader(w, r.Body, 512)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dst); err != nil {
+		var syntaxError *json.SyntaxError
+		var unmarshalTypeError *json.UnmarshalTypeError
+
+		switch {
+		// Handle syntax errors.
+		case errors.As(err, &syntaxError):
+			errorMessage := fmt.Sprintf("Request body contains a badly formatted JSON at position %d!", syntaxError.Offset)
+			return NewFailureResponse(http.StatusBadRequest, errorMessage)
+
+		// Handle unexpected EOFs.
+		case errors.Is(err, io.ErrUnexpectedEOF):
+			errorMessage := "Request body contains a badly-formed JSON!"
+			return NewFailureResponse(http.StatusBadRequest, errorMessage)
+
+		// Handle wrong data-type in request body.
+		case errors.As(err, &unmarshalTypeError):
+			errorMessage := fmt.Sprintf("Request body contains an invalid value for the %q field at position %d!", unmarshalTypeError.Field, unmarshalTypeError.Offset)
+			return NewFailureResponse(http.StatusBadRequest, errorMessage)
+
+		// Handle unknown fields.
+		case strings.HasPrefix(err.Error(), "json: unknown field "):
+			fieldName := strings.TrimPrefix(err.Error(), "json: unknown field ")
+			errorMessage := fmt.Sprintf("Request body contains unknown field '%s'!", fieldName)
+			return NewFailureResponse(http.StatusBadRequest, errorMessage)
+
+		// Handle empty request body.
+		case errors.Is(err, io.EOF):
+			errorMessage := "Request body must not be empty!"
+			return NewFailureResponse(http.StatusBadRequest, errorMessage)
+
+		// Handle too large body.
+		case err.Error() == "http: request body too large":
+			errorMessage := "Request body must not be larger than 512 bytes!"
+			return NewFailureResponse(http.StatusRequestEntityTooLarge, errorMessage)
+
+		// Handle other errors.
+		default:
+			return NewFailureResponse(http.StatusInternalServerError, err.Error())
+		}
+	}
+	defer r.Body.Close()
+
+	// Handle if client tries to send more than one JSON object.
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		errorMessage := "Request body must only contain a single JSON object!"
+		return NewFailureResponse(http.StatusBadRequest, errorMessage)
+	}
+
+	// If everything goes well, don't return anything.
+	return nil
 }
 
 // Configure is used to configure the application (server is initialized in 'main').

--- a/internal/application/nethttp.go
+++ b/internal/application/nethttp.go
@@ -202,6 +202,7 @@ func Configure() http.Handler {
 			})
 			if err != nil {
 				sendFailureResponse(w, NewFailureResponse(http.StatusInternalServerError, err.Error()))
+				return
 			}
 
 			// Make a response body. This is for development only. Production will send the OTP via other methods.

--- a/internal/application/nethttp.go
+++ b/internal/application/nethttp.go
@@ -211,6 +211,7 @@ func Configure() http.Handler {
 			decodedBasicAuth, err := base64.StdEncoding.DecodeString(basicAuthInformation)
 			if err != nil {
 				sendFailureResponse(w, NewFailureResponse(http.StatusInternalServerError, err.Error()))
+				return
 			}
 
 			// Anonymous struct.

--- a/internal/application/nethttp_test.go
+++ b/internal/application/nethttp_test.go
@@ -1,0 +1,89 @@
+package application
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func structToJSON(object interface{}) string {
+	out, err := json.Marshal(object)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	return string(out)
+}
+
+func TestGeneralHandlers(t *testing.T) {
+	handler := Configure()
+	testServer := httptest.NewServer(handler)
+	defer testServer.Close()
+
+	failureTests := []struct {
+		name           string
+		method         string
+		route          string
+		expectedStatus int
+		expectedBody   *FailureResponse
+	}{
+		{
+			name:           "test_failure_not_found",
+			method:         http.MethodGet,
+			route:          "/api/v1/404",
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   NewFailureResponse(http.StatusNotFound, "Route '/api/v1/404' with method 'GET' does not exist in this server!"),
+		},
+		{
+			name:           "test_failure_method_not_allowed",
+			method:         http.MethodDelete,
+			route:          "/api/v1",
+			expectedStatus: http.StatusMethodNotAllowed,
+			expectedBody:   NewFailureResponse(http.StatusMethodNotAllowed, "Method 'DELETE' is not allowed in this route!"),
+		},
+	}
+
+	successTests := []struct {
+		name           string
+		method         string
+		route          string
+		expectedStatus int
+		expectedBody   *SuccessResponse
+	}{
+		{
+			name:           "test_health_check",
+			method:         http.MethodGet,
+			route:          "/api/v1",
+			expectedStatus: http.StatusOK,
+			expectedBody:   NewSuccessResponse(http.StatusOK, "Welcome to 'net/http' API!"),
+		},
+	}
+
+	for _, tt := range failureTests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(tt.method, tt.route, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, r)
+
+			assert.NotNil(t, w.Body)
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			assert.JSONEq(t, structToJSON(tt.expectedBody), w.Body.String())
+		})
+	}
+
+	for _, tt := range successTests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(tt.method, tt.route, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, r)
+
+			assert.NotNil(t, w.Body)
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			assert.JSONEq(t, structToJSON(tt.expectedBody), w.Body.String())
+		})
+	}
+}

--- a/internal/application/nethttp_test.go
+++ b/internal/application/nethttp_test.go
@@ -59,7 +59,7 @@ func TestGeneralHandlers(t *testing.T) {
 			method:         http.MethodGet,
 			route:          "/api/v1",
 			expectedStatus: http.StatusOK,
-			expectedBody:   NewSuccessResponse(http.StatusOK, "Welcome to 'net/http' API!"),
+			expectedBody:   NewSuccessResponse(http.StatusOK, "Welcome to 'net/http' API!", nil),
 		},
 	}
 

--- a/internal/application/nethttp_test.go
+++ b/internal/application/nethttp_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -84,6 +85,107 @@ func TestGeneralHandlers(t *testing.T) {
 			assert.NotNil(t, w.Body)
 			assert.Equal(t, tt.expectedStatus, w.Code)
 			assert.JSONEq(t, structToJSON(tt.expectedBody), w.Body.String())
+		})
+	}
+}
+
+func TestDecodeJSONBody(t *testing.T) {
+	handler := Configure()
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	tests := []struct {
+		name         string
+		method       string
+		route        string
+		input        string
+		expectedBody *FailureResponse
+		withHeader   bool
+	}{
+		{
+			name:         "test_content_type",
+			method:       http.MethodPost,
+			route:        "/api/v1",
+			input:        `{"username":"kaede","password":"kaede"}`,
+			expectedBody: NewFailureResponse(http.StatusUnsupportedMediaType, "The 'Content-Type' header is not 'application/json'!"),
+			withHeader:   false,
+		},
+		{
+			name:         "test_json_bad_format",
+			method:       http.MethodPost,
+			route:        "/api/v1",
+			input:        `{"username":"kaede","password":"kaede",examplebadinput}`,
+			expectedBody: NewFailureResponse(http.StatusBadRequest, "Request body contains a badly formatted JSON at position 40!"),
+			withHeader:   true,
+		},
+		{
+			name:         "test_json_unexpected_eof",
+			method:       http.MethodPost,
+			route:        "/api/v1",
+			input:        `{"username":"kaede","password":"kaede"`,
+			expectedBody: NewFailureResponse(http.StatusBadRequest, "Request body contains a badly-formed JSON!"),
+			withHeader:   true,
+		},
+		{
+			name:         "test_json_wrong_data_type",
+			method:       http.MethodPost,
+			route:        "/api/v1",
+			input:        `{"username":"kaede","password":1234}`,
+			expectedBody: NewFailureResponse(http.StatusBadRequest, "Request body contains an invalid value for the \"password\" field at position 35!"),
+			withHeader:   true,
+		},
+		{
+			name:         "test_json_unknown_field",
+			method:       http.MethodPost,
+			route:        "/api/v1",
+			input:        `{"username":"kaede","password":"kaede","unknownAttribute":"1234"}`,
+			expectedBody: NewFailureResponse(http.StatusBadRequest, "Request body contains unknown field '\"unknownAttribute\"'!"),
+			withHeader:   true,
+		},
+		{
+			name:         "test_json_empty",
+			method:       http.MethodPost,
+			route:        "/api/v1",
+			input:        "",
+			expectedBody: NewFailureResponse(http.StatusBadRequest, "Request body must not be empty!"),
+			withHeader:   true,
+		},
+		{
+			name:         "test_json_too_large",
+			method:       http.MethodPost,
+			route:        "/api/v1",
+			input:        `{"username":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede","password":"kaede"}`,
+			expectedBody: NewFailureResponse(http.StatusRequestEntityTooLarge, "Request body must not be larger than 512 bytes!"),
+			withHeader:   true,
+		},
+		{
+			name:         "test_double_json",
+			method:       http.MethodPost,
+			route:        "/api/v1",
+			input:        "{}{}",
+			expectedBody: NewFailureResponse(http.StatusBadRequest, "Request body must only contain a single JSON object!"),
+			withHeader:   true,
+		},
+		{
+			name:         "test_success",
+			method:       http.MethodPost,
+			route:        "/api/v1",
+			input:        `{"username":"kaede","password":"kaede"}`,
+			expectedBody: nil,
+			withHeader:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(tt.method, tt.route, strings.NewReader(tt.input))
+			w := httptest.NewRecorder()
+			if tt.withHeader {
+				r.Header.Set("Content-Type", "application/json")
+			}
+
+			failureResponse := decodeJSONBody(w, r, &AuthRequestBody{})
+			assert.JSONEq(t, structToJSON(tt.expectedBody), structToJSON(failureResponse))
 		})
 	}
 }

--- a/scripts/e2e-testing.sh
+++ b/scripts/e2e-testing.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+main() {
+  curl -X POST -d '{"username":"kaede","password":"kaede"}' -H "Content-Type: application/json" http://localhost:8080/api/v1
+}
+
+# Run main function.
+main


### PR DESCRIPTION
This PR adds:

- Implement web server with `net/http`, and `go-chi` as the router. Complete with graceful shutdown.
- Implement modern JSON decoder.
- Implement basic sign in functionality and OTP that conforms to RFC 6238.
- Implement verification (Basic Authorization) with `user:OTP` that conforms to RFC 7617.
- Write unit tests for said functions and routes.